### PR TITLE
#166608419  Users can register as patron or author

### DIFF
--- a/hello-books-swagger.json
+++ b/hello-books-swagger.json
@@ -77,7 +77,7 @@
           {
             "in": "body",
             "name": "body",
-            "description": "This is the request body object containing users' signup information. Role can 'patron' or 'author'",
+            "description": "This is the request body object containing users' signup information. Role can be 'patron' or 'author'",
             "required": true,
             "schema": {
               "$ref": "#/definitions/UserSignupRequest"

--- a/hello-books-swagger.json
+++ b/hello-books-swagger.json
@@ -77,7 +77,7 @@
           {
             "in": "body",
             "name": "body",
-            "description": "This is the request body object containing users' signup information",
+            "description": "This is the request body object containing users' signup information. Role can 'patron' or 'author'",
             "required": true,
             "schema": {
               "$ref": "#/definitions/UserSignupRequest"
@@ -271,6 +271,10 @@
           "description": "Last name of the user",
           "type": "string"
         },
+        "role": {
+          "description": "role of the user",
+          "type": "string"
+        },
         "password": {
           "description": "Password of the user",
           "type": "string"
@@ -281,7 +285,8 @@
         "email": "example@user.com",
         "firstName": "Marky",
         "lastName": "Steve",
-        "password": "hellobooks"
+        "role": "author",
+        "password": "Hellobooks2019"
       }
     },
     "UserLoginRequest": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "cross-env NODE_ENV=test npm run clean-tables && nyc --reporter=text mocha ./server/test/*.spec.js --require @babel/register --require @babel/polyfill --slow 400 --timeout 5000 --color --exit",
     "start": "cross-env NODE_ENV=production npm run build && node ./build/index.js",
-    "start-dev": "cross-env NODE_ENV=development DEBUG=dev nodemon --exec babel-node index.js",
+    "dev": "cross-env NODE_ENV=development DEBUG=dev nodemon --exec babel-node index.js",
     "build-babel": "babel -d ./build index.js && babel ./server --out-dir build/server",
     "build": "npm run clean && npm run build-babel",
     "clean": "rm -rf build && mkdir build && cp hello-books-swagger.json build",

--- a/server/config/buildTables.js
+++ b/server/config/buildTables.js
@@ -11,7 +11,8 @@ const userTableQuery = `
     "lastName" VARCHAR(100) NOT NULL,
     "email" VARCHAR(100) UNIQUE NOT NULL,
     "password" TEXT NOT NULL,
-    "role" INTEGER DEFAULT 0,
+    role INTEGER NOT NULL,
+    "isAdmin" boolean NOT NULL DEFAULT false,
     "emailConfirmCode" VARCHAR(64),
     "createdOn" TIMESTAMPTZ DEFAULT now() NOT NULL
   );
@@ -29,6 +30,14 @@ const userProfileTableQuery = `
     PRIMARY KEY ("userId")
   );
 `;
+
+const rolesTableQuery = `
+    CREATE TABLE IF NOT EXISTS roles(
+      id SERIAL PRIMARY KEY,
+      name VARCHAR(100) UNIQUE NOT NULL
+    );
+`;
+
 
 const bookTableQuery = `
 CREATE TABLE IF NOT EXISTS books(
@@ -50,7 +59,9 @@ const createTable = async () => {
   try {
     await pool.query(`${userTableQuery}
     ${userProfileTableQuery}
-    ${bookTableQuery}`);
+    ${bookTableQuery}
+    ${rolesTableQuery}
+ `);
     debug('Tables created successfully');
   } catch (error) {
     debug(error);

--- a/server/config/dropTables.js
+++ b/server/config/dropTables.js
@@ -10,7 +10,7 @@ const debug = Debug('dev');
  */
 const dropTable = async () => {
   try {
-    await pool.query('DROP TABLE IF EXISTS user_profiles, users');
+    await pool.query('DROP TABLE IF EXISTS user_profiles, users, books, roles');
     debug('Tables dropped successfully');
   } catch (error) {
     debug(error);

--- a/server/config/seed.js
+++ b/server/config/seed.js
@@ -14,16 +14,20 @@ const insertSeed = async () => {
   const hashedPassword = encryptPassword('nonsoDrums');
   const seed = `
   INSERT INTO users(
-    "userName", "firstName", "lastName", email, password
+    "userName", "firstName", "lastName", email, password, role
   )
   VALUES (
-    'xwebyna', 'Tolu', 'Martins', 'nero.abdul@gmail.com', '${hashedPassword}'
+    'xwebyna', 'Tolu', 'Martins', 'nero.abdul@gmail.com', '${hashedPassword}', 1
     )
   ON CONFLICT (email)
   DO NOTHING;
 `;
+
   try {
     await pool.query(seed);
+    await pool.query(`INSERT INTO roles (name)
+    VALUES
+       ('user'), ('author'), ('cashier'), ('admin'), ('superAdmin');`);
     debug('insert succeeded');
   } catch (error) {
     debug(error);

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -22,15 +22,22 @@ export default class Users {
       firstName,
       lastName,
       password,
-      emailConfirmCode
+      emailConfirmCode,
     } = user;
+    let { role } = user;
+    if (role === 'patron') {
+      role = 1;
+    } else if (role === 'author') {
+      role = 2;
+    }
     const { rows } = await pool.query(
       `INSERT INTO 
     users
-    ("userName", email, "firstName", "lastName", password, "emailConfirmCode")
-    VALUES ($1, $2, $3, $4, $5, $6)
+    ("userName", email, "firstName", "lastName", password, "emailConfirmCode",
+    role)
+    VALUES ($1, $2, $3, $4, $5, $6, $7)
     RETURNING *`,
-      [userName, email, firstName, lastName, password, emailConfirmCode]
+      [userName, email, firstName, lastName, password, emailConfirmCode, role]
     );
     return rows[0];
   }

--- a/server/schema/userRegistration.js
+++ b/server/schema/userRegistration.js
@@ -140,5 +140,10 @@ export default {
         }
       });
       return errors;
-    })
+    }),
+
+  role: Joi.string()
+    .valid('patron', 'author')
+    .trim()
+    .required()
 };

--- a/server/test/mockdata.test.js
+++ b/server/test/mockdata.test.js
@@ -4,7 +4,8 @@ const inputs = {
     email: 'reader1@gmail.com',
     firstName: 'John',
     lastName: 'Doe',
-    password: 'Books123'
+    password: 'Books123',
+    role: 'author'
   },
   validSignUpInputs: [
     {
@@ -12,21 +13,24 @@ const inputs = {
       email: 'reader1@gmail.com',
       firstName: 'John',
       lastName: 'Doe',
-      password: 'Books123'
+      password: 'Books123',
+      role: 'patron'
     },
     {
       userName: 'reader2',
       email: 'reader2@gmail.com',
       firstName: 'Mark',
       lastName: 'Diamond',
-      password: 'Books231'
+      password: 'Books231',
+      role: 'author'
     },
     {
       userName: 'reader3',
       email: 'toolzdman@gmail.com',
       firstName: 'Rihanna',
       lastName: 'Obayomi',
-      password: 'Books123'
+      password: 'Books123',
+      role: 'patron'
     }
   ],
 
@@ -36,14 +40,16 @@ const inputs = {
       email: 'reader1000@gmail.com',
       firstName: 'John',
       lastName: 'Doe',
-      password: 'Books1'
+      password: 'Books1',
+      role: 'author'
     },
     {
       userName: 'reader100',
       email: 'reader1@gmail.com',
       firstName: 'John',
       lastName: 'Doe',
-      password: 'Books1'
+      password: 'Books1',
+      role: 'patron'
     }
   ],
 

--- a/server/utilities/emailModule.js
+++ b/server/utilities/emailModule.js
@@ -1,9 +1,10 @@
 import sendGridMail from '@sendgrid/mail';
 import dotenv from 'dotenv';
+import Debug from 'debug';
 
 dotenv.config();
 sendGridMail.setApiKey(process.env.SENDGRID_API_KEY);
-const { log } = console;
+const debug = Debug('dev');
 
 /**
  * Contains methods for handling user email services
@@ -34,10 +35,10 @@ class EmailModule {
 
     try {
       await sendGridMail.send(emailData);
-      log('Email sent successfully');
+      debug('Email sent successfully');
       return true;
     } catch (error) {
-      log(error.response.body);
+      debug(error.response.body);
       return false;
     }
   }

--- a/server/utilities/emailModule.js
+++ b/server/utilities/emailModule.js
@@ -1,10 +1,10 @@
 import sendGridMail from '@sendgrid/mail';
 import dotenv from 'dotenv';
-import Debug from 'debug';
 
 dotenv.config();
 sendGridMail.setApiKey(process.env.SENDGRID_API_KEY);
-const debug = Debug('dev');
+const { log } = console;
+
 /**
  * Contains methods for handling user email services
  *
@@ -21,7 +21,7 @@ class EmailModule {
    * @param {object} receiver - Object contains "name" and "email" of receiver
    * @param {string} subject - Subject of the email
    * @param {string} content - Content of the email
-   * @returns {string} Information about whether or not the operation succeeds
+   * @returns {boolean} Information about whether or not the operation succeeds
    * @memberof EmailModule
    */
   static async sendEmailToUser(receiver, subject, content) {
@@ -34,11 +34,11 @@ class EmailModule {
 
     try {
       await sendGridMail.send(emailData);
-      debug('Email sent successfully');
-      return 'Email sent successfully';
+      log('Email sent successfully');
+      return true;
     } catch (error) {
-      debug(error.response.body);
-      throw new Error(error.response.body);
+      log(error.response.body);
+      return false;
     }
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Enables users to select patron or author role when  registering  an account

#### Description of Task to be completed?
Have the  feature working on signup route  ```/api/v1/auth/signup```. Enables users to select user roles.

#### How should this be manually tested?
The feature can be tested with any API testing application, like postman. It can as well be tested on the swagger documentation route.

- Clone the REPO and checkout to ```ft-user-signup-as-author-166608419```.  Add all required env variables.
- Run  ```npm run migration```. follow by ```npm start```, and use your API testing app to test the above API endpoints.

>- Additional required field at signup ```role```  - _patron or author_

#### Any background context you want to provide?
Author users should be to create an account on the application and able to upload ebooks or supply books to the library. 

#### What are the relevant pivotal tracker stories?
[#166608419](https://www.pivotaltracker.com/story/show/166608419)

#### Screenshots (if appropriate)
![role](https://user-images.githubusercontent.com/42908597/59396376-5dc48000-8d80-11e9-989c-dd9f58d6fb19.PNG)

